### PR TITLE
feat: adds diary to squelch logs sometimes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "commander": "^6.2.0",
+    "diary": "^0.1.6",
     "glob": "^7.1.6",
     "search-trie": "^2.0.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,10 @@ import {removeNestedDirectories} from "./utils";
 
 export {findProjectRoot} from './configuration';
 
+import {diary} from 'diary';
+
+const {log} = diary('idea-exclude');
+
 /**
  * Excludes list of files creating a named group
  * @param root
@@ -22,7 +26,9 @@ export const exclude = async (root: string, group: string, files: string[]) => {
   if (!ideaFile) {
     throw new Error(`💥 no .idea configuration file found at ${root} ~ ${baseName}`);
   }
-  console.log('🔎 found idea config:', ideaFile);
+
+  log('excluding %s with %f files', relative(baseName, ideaFile), files.length);
+
   const originalConfiguration: string =
     prepareIml(
       (await readFile(ideaFile)).toString("utf-8")
@@ -36,6 +42,7 @@ export const exclude = async (root: string, group: string, files: string[]) => {
 
   if (finalConfiguration !== originalConfiguration) {
     await writeFile(ideaFile, finalConfiguration);
+    log('updated %s', relative(baseName, ideaFile));
   }
 
   return files;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1170,6 +1170,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+diary@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/diary/-/diary-0.1.6.tgz#112e564a8d507bf15887ccbbeea9bff540e46cb5"
+  integrity sha512-5xoYu+2Lbv4mQ5rnAFMYJrX9zpsT8sS2U5ihzDpCwUzgHvN3jwov077wGvIxxAL+zt5S/6A3OWUYls2pMcPixg==
+
 diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"


### PR DESCRIPTION
### Problem

In scenarios where you re potentiality wanting to exclude more than one thing (using the js api). You end up with many `🔎 found idea config` console messages that are all largely useless. 

### Solution

Leveraging diary we can squash these log entries as well as make them slightly more usable.

We now see 2 entries

```
excluding path/to/file with 3 files
```
> if the idea file exists

then later _if there was a diff_

```
updated path/to/file
```
> if there was a change

Example:

![image](https://user-images.githubusercontent.com/599459/128119224-525fc3ac-6356-41ab-8cdc-d726c320ef0a.png)
